### PR TITLE
adjust font fallback order & add fallback font for OSX

### DIFF
--- a/src/asset/css/detail.css
+++ b/src/asset/css/detail.css
@@ -2,7 +2,7 @@ html {
   background: #ECECEC;
 }
 body, pre {
-	font: 16px / 1.5 "微软雅黑", Helvetica, Serif;
+  font: 16px / 1.5 Helvetica, "Microsoft Yahei", "Hiragino Sans GB", sans;
   color: #222;
 }
 .page-wrap, .title-wrap {

--- a/src/asset/css/doc.css
+++ b/src/asset/css/doc.css
@@ -2,7 +2,7 @@ html {
   background: url('../image/creampaper.png');
 }
 body {
-	font: 16px / 1.5 "微软雅黑", Helvetica, Serif;
+  font: 16px / 1.5 Helvetica, "Microsoft Yahei", "Hiragino Sans GB", sans;
 }
 
 ul {

--- a/src/asset/css/welcome.css
+++ b/src/asset/css/welcome.css
@@ -4,7 +4,7 @@ html {
 }
 
 body {
-	font: 16px / 1.5 "微软雅黑", Helvetica, Serif;
+  font: 16px / 1.5 Helvetica, "Microsoft Yahei", "Hiragino Sans GB", sans;
 	text-align:center;
 }
 


### PR DESCRIPTION
原先的font-family設定會導致OSX下字型顯示怪怪的……於是調了一下…

+ 原先把英文字型放在了中文字型後面，現在換到了前面。
+ 原先的最終fallback是serif（有襯線型），與前面指定的無襯線字型風格不一致，現在改成sans。
+ 微軟雅黑改用英文名"Microsoft Yahei"以免因字符編碼識別錯誤導致字型不正常…
+ 增加了一個Hiragino Sans GB，這是OSX的簡體中文預設字型，適用於未安裝MS Office的OSX。