### PR TITLE
确保 README 中 ** 会被解析成 <strong>

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,56 +33,56 @@ Use `grunt dev` to watch changes in `src/`
 
 ## Revision History
 
-** v3.3.1 **
+**v3.3.1**
 * FIX discusstion reply bug
 
-** v3.3.0 **
+**v3.3.0**
 * ADD discusstion collection
 * FIX icon error
 * rebuild project, using grunt build completely
 
-** v3.2.3 **
+**v3.2.3**
 * FIX display items repeatly when refresh
 
-** v3.2.2 **
+**v3.2.2**
 * add installation checking code
 
-** v3.2.0 **
+**v3.2.0**
 * hide term-model when first time open
 * move to Chrome Web Store
 
-** v3.1.0 **
+**v3.1.0**
 * FIX clear div when clearing data
 * automaticaly switch to new term
 
-** v3.0.1 **
+**v3.0.1**
 * css fix
 
-** v3.0.0 **
+**v3.0.0**
 * move all logic to `background.iced`
 * auto login after long time no-operation
 * do not refresh data when reopen in 5min
 * add off-line mode for homework and announcement by adding a cache
 
-** v2.2.1 **
+**v2.2.1**
 * bug fixed
 
-** v2.2.0 **
+**v2.2.0**
 * FIX wrong href target
 * ignore unfinished homework that exceed the time limit
 
-** v2.1.0 **
+**v2.1.0**
 * ADD file collection function
 * add function to update database smoothly
 * ADD changelog page
 * FIX bug of displaying course name #4
 * FIX unread message number
 
-** v2.0.1 **
+**v2.0.1**
 * FIX refresh button bug
 * FIX security problem of saved password
 * show version info in index page
 
-** v2.0.0 **
+**v2.0.0**
 * evernote-like UI
 * collect Homework and Announcement


### PR DESCRIPTION
发现 README 的 Revision History 底下版本号没有成功黑体

似乎是由于 Markdown 的一个语法细节

>  But if you surround an * or _ with spaces, it’ll be treated as a literal asterisk or underscore.

只是强迫症犯了 orz…如果本意就是 ** 的话请无视~