### PR TITLE
Added a fix for upcoming chrome changes. Rephrased yarn commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Or you can install the unpacked version from releases
 
 Learn Helper is built using `yarn`:
 ```bash
-yarn
-yarn run dev-build # for develop build
-yarn run dev-watch # for develop build with watching
-yarn run format # run prettier
-yarn run build # for release build
+yarn --frozen-lockfile
+yarn dev-build # for develop build
+yarn dev-watch # for develop build with watching
+yarn format # run prettier
+yarn build # for release build
 ```
 
 You may need to run build commands more than once to get the correct output.

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -10,12 +10,15 @@
 			"browser-polyfill.min.js",
 			"background.js"
 		],
-        "persistent": false
+        "persistent": true
 	},
 	"permissions": [
 		"storage",
 		"tabs",
 		"downloads",
+        "cookies",
+        "webRequest",
+        "webRequestBlocking",
 		"https://learn.tsinghua.edu.cn/*",
 		"https://learn2018.tsinghua.edu.cn/*",
 		"https://id.tsinghua.edu.cn/*"

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,9 +21,12 @@ function rewriteCookie(e) {
   return { responseHeaders: e.responseHeaders }
 }
 
+const opts = ['blocking', 'responseHeaders'];
+if(navigator.userAgent.indexOf('Chrome') !== -1) opts.push('extraHeaders')
+
 if(!browser.webRequest.onHeadersReceived.hasListener(rewriteCookie))
   browser.webRequest.onHeadersReceived.addListener(rewriteCookie, {
     urls: [
       'https://learn2018.tsinghua.edu.cn/*',
     ],
-  }, ['blocking', 'responseHeaders', 'extraHeaders']);
+  }, opts);

--- a/src/background.ts
+++ b/src/background.ts
@@ -7,3 +7,23 @@ const clickListener = () => {
 if (!browser.browserAction.onClicked.hasListener(clickListener)) {
   browser.browserAction.onClicked.addListener(clickListener);
 }
+
+function rewriteCookie(e) {
+  e.responseHeaders.forEach(header => {
+    if(header.name.toLowerCase() === 'set-cookie')
+      header.value += '; SameSite=None; Secure';
+    else if(header.name.toLowerCase() === 'location') {
+      if(header.value.indexOf('http:') === 0)
+        header.value = 'https:' + header.value.substr(5);
+    }
+  });
+
+  return { responseHeaders: e.responseHeaders }
+}
+
+if(!browser.webRequest.onHeadersReceived.hasListener(rewriteCookie))
+  browser.webRequest.onHeadersReceived.addListener(rewriteCookie, {
+    urls: [
+      'https://learn2018.tsinghua.edu.cn/*',
+    ],
+  }, ['blocking', 'responseHeaders', 'extraHeaders']);


### PR DESCRIPTION
Chrome is planning to default same-site policy for cookies to SameSite=Lax, which will effectively remove those cookies from CORS requests. [1]

Dev users are already experiencing the error caused by the change. Beta users is expected to receive the change on Oct 22nd [2] (Beta 78). Stable 90 (in 2020) will receive the change.

By using webRequest, we can forcefully add a SameSite=None rule into Set-Cookie headers in responses. Unfortunately, to do so, we need to introduce three additional permission
- `webRequest` for intercepting responses
- `webRequestBlocking` for modifying responses.
- `cookies` for reading cookie related headers

Chrome also requires an non-standard option with the webRequest API: extraHeaders [3]. Currently Firefox is really unhappy about this, but I guess we'll see.

Additionally, I'm changing all HTTP redirect into HTTPS, because SameSite=None requires Secure. Also, security matters.

[1] https://www.chromestatus.com/feature/5088147346030592
[2] https://www.chromium.org/developers/calendar
[3] https://developer.chrome.com/extensions/webRequest