### PR TITLE
fix #85: 作业页面显示的图标不对齐

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -169,7 +169,7 @@ class ContentCard extends React.PureComponent<CardProps, never> {
       <Badge variant="dot" color="secondary" invisible={content.hasRead}>
         <Chip
           avatar={icon}
-          label={<span className={styles.card_chip_text}>{label}</span>}
+          label={<div className={styles.card_chip_text}>{label}</div>}
           className={classnames(styles[className], styles.card_func_chip)}
         />
       </Badge>


### PR DESCRIPTION
fix #85 
经过我的分析，问题的原因是：Material UI进行了更新，导致了CSS发生变化。作业页面的图标使用的是Material UI的`Chip`组件，它的属性`label`是用一个`<span class="MuiChip-label">`包裹的。  
然而Material UI的旧版本中有
```css
.MuiChip-label{
    display: flex
}
```
的css，可是在新版本中这段css被删除了。造成`<span class="MuiChip-label">`的display是默认的block。而我们在里面插入的标签是`<span>`，所以里面的span计算出的display是inline。inline的属性上设置min-width是不生效的。  
我们很难改变Material UI库的css写法，因而只能改这个项目本身的代码。我认为问题的根本在于，里面的日期数字既然想要通过min-width控制其宽度，就不应该再使用span了；如果使用div的话那display默认的就是block，从而就不会有问题了。因此我的修改方法就是把span改为div。  
上述修改在我本人的机器上build并安装到chrome后是有效的。  
PS：感谢本项目原始的开发者们一直以来给我们带来的便利，辛苦了！