### PR TITLE
尝试修复#81 和#87 中提到的多次点击课程文件会无法预览的问题

### DIFF
--- a/src/components/ContentDetail.tsx
+++ b/src/components/ContentDetail.tsx
@@ -11,7 +11,7 @@ import { HomeworkInfo, NotificationInfo, FileInfo } from '../types/data';
 import { formatDateTime } from '../utils/format';
 import { setDetailUrl } from '../redux/actions/ui';
 
-class ContentDetail extends React.PureComponent<ContentDetailProps, never> {
+class ContentDetail extends React.PureComponent<ContentDetailProps, {frameUrl?: string}> {
   public render() {
     const content = this.props.content;
     const homework = content as HomeworkInfo;
@@ -28,6 +28,16 @@ class ContentDetail extends React.PureComponent<ContentDetailProps, never> {
       : notification.content;
     if (contentDetail !== undefined) contentDetail = contentDetail.trim();
     if (contentDetail === undefined || contentDetail === '') contentDetail = '详情为空';
+
+    // When `file.previewUrl` is changed (i.e file.previewUrl is not undefined and not equals to
+    // this.state.frameUrl), do not set the <Iframe>'s `url` attribute immediately.
+    // Instead, remove the IFrame label first, and set state `frameUrl` =`file.previewUrl`.
+    // Thus, the component will be update later with correct state, to recreate the <IFrame>` label
+    // rather than reuse the old one.
+    const shouldRemoveIframeFirst = file.previewUrl && this.state?.frameUrl !== file.previewUrl;
+    if (shouldRemoveIframeFirst) {
+      this.setState({ frameUrl: file.previewUrl });
+    }
 
     return (
       <section className={styles.content_detail}>
@@ -46,8 +56,8 @@ class ContentDetail extends React.PureComponent<ContentDetailProps, never> {
           className={styles.content_detail_content}
           dangerouslySetInnerHTML={{ __html: contentDetail }}
         />
-        {isFile && this.canFilePreview(file) ? (
-          <Iframe className={styles.content_detail_preview} url={file.previewUrl} />
+        {!shouldRemoveIframeFirst && isFile && this.canFilePreview(file) ? (
+          <Iframe className={styles.content_detail_preview} url={this.state?.frameUrl} />
         ) : null}
       </section>
     );

--- a/src/components/DetailPane.tsx
+++ b/src/components/DetailPane.tsx
@@ -12,7 +12,7 @@ import ContentDetail from './ContentDetail';
 
 import styles from '../css/main.css';
 
-class DetailPane extends React.PureComponent<DetailPaneProps, never> {
+class DetailPane extends React.PureComponent<DetailPaneProps, {frameUrl?: string}> {
   public render() {
     if (this.props.showIgnoreSettings) {
       return <ContentIgnoreSetting />;
@@ -20,6 +20,14 @@ class DetailPane extends React.PureComponent<DetailPaneProps, never> {
     if (this.props.content !== undefined) {
       return <ContentDetail content={this.props.content} />;
     }
+
+    // When prop `url` is changed, first remove the IFrame label and then recreate it,
+    // rather than reuse the old one.
+    const shouldRemoveIframeFirst = this.props.url && this.state?.frameUrl !== this.props.url;
+    if (shouldRemoveIframeFirst) {
+      this.setState({ frameUrl: this.props.url });
+    }
+
     return (
       <section
         style={{
@@ -28,7 +36,9 @@ class DetailPane extends React.PureComponent<DetailPaneProps, never> {
           position: 'relative',
         }}
       >
-        <Iframe className={styles.web_frame} url={this.props.url} />
+        {!shouldRemoveIframeFirst ? (
+          <Iframe className={styles.web_frame} url={this.state?.frameUrl} />
+        ) : null}
       </section>
     );
   }


### PR DESCRIPTION
这个问题在 #81 和 #87 中已经有了很多探讨。直接原因是Chrome把我们的加载iframe当成了cross-site的请求来看待、导致cookie不会被发送；不过这是不应当的，看起来是Chrome实现的bug。  
等Chrome修复怕不是很难的\doge\doge，本PR尝试用从自己身上解决问题：因为观察到第一次点击课程文件是不会有问题的，这说明如果在iframe加载的时候直接指定的url是不会有问题的；而后续点击出现问题说明如果修改iframe的url属性来实现切换页面的话就会出问题。  
因此我的解决方式也相对简单：每当课程文件的file.previewUrl改变的时候，不要通过简单的修改原来的<Iframe>的url的属性来切换页面，而是强制把之前的<Iframe>移除掉，并把一个新的直接指向正确链接的<Iframe>添加回来。  
上述修改在本人的机器上build并安装到Chrome测试后是有效的，能够解决了 #81 和 #87 中提到的问题。  
PS：感谢本项目原始的开发者们一直以来给我们带来的便利，辛苦了！